### PR TITLE
Fix failing macOS test runner

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -40,6 +40,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -57,6 +58,18 @@ jobs:
           path: ${{ matrix.prefix }}
           key: ${{ matrix.label }}-py${{ matrix.python-version }}-conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
         id: cache
+
+      - name: Update system packages
+        run: |
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            brew update && brew upgrade && brew install openssl
+            cd /usr/local/Cellar/openssl/1.0.2t/lib
+            sudo cp libssl.1.0.0.dylib libcrypto.1.0.0.dylib /usr/local/lib/
+            cd /usr/local/lib
+            sudo ln -s libssl.1.0.0.dylib libssl.dylib
+            sudo ln -s libcrypto.1.0.0.dylib libcrypto.dylib
+            cd ~
+          fi
 
       - name: Update environment
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -18,12 +18,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "windows-latest" ]
+        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
         python-version: [ "3.7", "3.8", "3.9", "3.10" ]
         include:
           - os: ubuntu-latest
             label: linux-64
             prefix: /usr/share/miniconda3/envs/my-env
+
+          - os: macos-latest
+            label: osx-64
+            prefix: /Users/runner/miniconda3/envs/my-env
 
           - os: windows-latest
             label: win-64


### PR DESCRIPTION


Getting "Abort trap: 6" on macos. These tests aren't failing because of hakai-segmentation code issues, but because of some kind of change that happened in the MacOS-latest test runner.

This seems related: https://dbaontap.com/2019/11/11/python-abort-trap-6-fix-after-catalina-update/

Related: #26