### PR TITLE
Move preprocessing transforms into model definition

### DIFF
--- a/kelp_o_matic/managers.py
+++ b/kelp_o_matic/managers.py
@@ -7,7 +7,6 @@ import rasterio
 from rich import print
 from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn
 from torch.utils.data import DataLoader
-from torchvision import transforms
 
 from kelp_o_matic.geotiff_io import GeotiffReader, GeotiffWriter
 from kelp_o_matic.models import _Model
@@ -18,13 +17,13 @@ class GeotiffSegmentationManager:
     """Class for configuring data io and efficient segmentation of Geotiff imagery."""
 
     def __init__(
-        self,
-        model: "_Model",
-        input_path: Union[str, "Path"],
-        output_path: Union[str, "Path"],
-        crop_size: int = 512,
-        padding: int = 256,
-        batch_size: int = 1,
+            self,
+            model: "_Model",
+            input_path: Union[str, "Path"],
+            output_path: Union[str, "Path"],
+            crop_size: int = 512,
+            padding: int = 256,
+            batch_size: int = 1,
     ):
         """Create the segmentation object.
 
@@ -41,18 +40,9 @@ class GeotiffSegmentationManager:
         """
         self.model = model
 
-        tran = transforms.Compose(
-            [
-                transforms.ToTensor(),
-                transforms.Lambda(lambda img: img[:3, :, :]),
-                transforms.Normalize(
-                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-                ),
-            ]
-        )
         self.reader = GeotiffReader(
             Path(input_path).expanduser().resolve(),
-            transform=tran,
+            transform=self.model.transform,
             crop_size=crop_size,
             padding=padding,
             filter_=self._should_keep,

--- a/kelp_o_matic/models.py
+++ b/kelp_o_matic/models.py
@@ -3,6 +3,7 @@ import importlib.resources as importlib_resources
 from abc import ABC, abstractmethod
 
 import torch
+import torchvision.transforms.functional as f
 
 from kelp_o_matic.data import (
     lraspp_kelp_presence_torchscript_path,
@@ -12,6 +13,12 @@ from kelp_o_matic.data import (
 
 
 class _Model(ABC):
+    @staticmethod
+    def transform(x: torch.Tensor) -> torch.Tensor:
+        x = f.to_tensor(x)[:3, :, :] / 255.0
+        x = f.normalize(x, mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+        return x
+
     def __init__(self, use_gpu: bool = True):
         is_cuda = torch.cuda.is_available() and use_gpu
         self.device = torch.device("cuda") if is_cuda else torch.device("cpu")


### PR DESCRIPTION
Transforms are often specific to the model the data is being fed into, so it makes sense to define them as part of the model.

This opens the door for releasing additional models that may have different transforms.  