### PR TITLE
Relax pytorch-cuda version

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - torchvision ~=0.16.1
     - typer ~=0.9.0
   run_constrained:
-    - pytorch-cuda ~= 11.8
+    - pytorch-cuda >= 11.8
 
 test:
   imports:


### PR DESCRIPTION
Allow use of e.g. 11.8 and 12.1 pytorch cuda instead of restricting to just 11.*